### PR TITLE
CASE Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         uses: kchason/case-validation-action@v1
         with:
           case-path: ./output/case.json
+          case-version: "case-0.6.0"
 
       # Upload the PyTest HTML coverage report for review
       - name: Upload PyTest Coverage

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import uuid
 import warnings
-from argparse import ArgumentParser
 from logging import CRITICAL
 from logging import DEBUG
 from logging import ERROR
@@ -17,7 +16,6 @@ from os.path import normpath
 from os.path import sep
 from time import time
 from warnings import warn
-from _version import __version__
 from sqlite_dissect.carving.rollback_journal_carver import RollBackJournalCarver
 from sqlite_dissect.carving.signature import Signature
 from sqlite_dissect.constants import BASE_VERSION_NUMBER
@@ -43,7 +41,6 @@ from sqlite_dissect.utilities import get_sqlite_files, create_directory, parse_a
 from sqlite_dissect.version_history import VersionHistory
 from sqlite_dissect.version_history import VersionHistoryParser
 from datetime import datetime
-import sys
 
 """
 
@@ -60,6 +57,9 @@ def main(arguments, sqlite_file_path, export_sub_paths=False):
 
     :param arguments: the object of key => value arguments that have been provided as the runtime configuration in which
         the SQLite Dissect tool should run.
+    :param sqlite_file_path: the string path to the SQLite file or directory being processed.
+    :param export_sub_paths: the boolean determination of whether to generate subdirectories for the output for each
+        SQLite file being processed.
     """
     # Handle the logging and warning settings
     if not arguments.log_level:

--- a/sqlite_dissect/export/case_export.py
+++ b/sqlite_dissect/export/case_export.py
@@ -32,7 +32,7 @@ class CaseExporter(object):
     # Defines the initial structure for the CASE export. This will be supplemented with various methods that get called
     # from the main.py execution path.
     case = {
-        '@context': {
+        "@context": {
             "@vocab": "http://example.org/ontology/local#",
             "case-investigation": "https://ontology.caseontology.org/case/investigation/",
             "drafting": "http://example.org/ontology/drafting#",
@@ -49,7 +49,7 @@ class CaseExporter(object):
             "uco-vocabulary": "https://unifiedcyberontology.org/ontology/uco/vocabulary#",
             "xsd": "http://www.w3.org/2001/XMLSchema#"
         },
-        '@graph': []
+        "@graph": []
     }
     start_datetime = None
     end_datetime = None
@@ -114,7 +114,7 @@ class CaseExporter(object):
             # Parse the file and get the attributes we need
             self.case['@graph'].append({
                 "@id": guid,
-                "@type": "uco-observable:ObservableObject",
+                "@type": "uco-observable:File",
                 "uco-observable:hasChanged": False,
                 "uco-core:hasFacet": [
                     {

--- a/sqlite_dissect/export/case_export.py
+++ b/sqlite_dissect/export/case_export.py
@@ -283,7 +283,9 @@ class CaseExporter(object):
         action = {
             "@id": ("kb:investigative-action" + str(uuid.uuid4())),
             "@type": "case-investigation:InvestigativeAction",
-            "uco-core:hasFacet": []
+            "uco-action:instrument": guid_list_to_objects([tool_guid]),
+            "uco-action:object": guid_list_to_objects(source_guids),
+            "uco-action:result": guid_list_to_objects(self.result_guids)
         }
 
         if self.start_datetime:
@@ -296,14 +298,6 @@ class CaseExporter(object):
                 "@type": "xsd:dateTime",
                 "@value": self.end_datetime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             }
-        # Loop through and add the results to the ActionReferencesFacet
-        action_facet = {
-            "@type": "uco-action:ActionReferencesFacet",
-            "uco-action:instrument": guid_list_to_objects([tool_guid]),
-            "uco-action:object": guid_list_to_objects(source_guids),
-            "uco-action:result": guid_list_to_objects(self.result_guids)
-        }
-        action["uco-core:hasFacet"].append(action_facet)
         self.case['@graph'].append(action)
 
     def export_case_file(self, export_path='output/case.json'):


### PR DESCRIPTION
Update the CASE output to comply with UCO 0.8.0 and CASE 0.6.0
- Switch the object type for files from `uco-observable:ObservableObject` to `uco-observable:File`
- Explicitly support CASE 0.6.0 (implies UCO 0.8.0) with validation action